### PR TITLE
Fix undefined 'bytes' reference in CommandApdu.toString()

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "compile": "babel -d lib/ src/",
     "compile:watch": "babel -w -d lib/ src/",
+    "test": "npm run compile && mocha test/**/*.test.js",
     "prepublish": "npm run compile",
     "release:patch": "npm run compile && npm version patch && git push && npm publish"
   },
@@ -36,6 +37,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",
-    "babel-preset-es2015": "^6.6.0"
+    "babel-preset-es2015": "^6.6.0",
+    "mocha": "^11.7.5"
   }
 }

--- a/src/command-apdu.js
+++ b/src/command-apdu.js
@@ -62,7 +62,7 @@ function CommandApdu(obj) {
 
 
 CommandApdu.prototype.toString = function() {
-    return hexify.toHexString(bytes);
+    return hexify.toHexString(this.bytes);
 };
 
 CommandApdu.prototype.toByteArray = function() {

--- a/test/command-apdu.test.js
+++ b/test/command-apdu.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var CommandApdu = require('../lib/command-apdu');
+var assert = require('assert');
+
+describe('CommandApdu', function() {
+    describe('toString()', function() {
+        it('should return hex string representation of the APDU', function() {
+            var apdu = CommandApdu({
+                cla: 0x00,
+                ins: 0xA4,
+                p1: 0x04,
+                p2: 0x00
+            });
+
+            var result = apdu.toString();
+
+            // Should not throw and should return a hex string
+            assert.ok(typeof result === 'string', 'toString() should return a string');
+            assert.ok(result.length > 0, 'toString() should return a non-empty string');
+        });
+
+        it('should return correct hex for a SELECT command', function() {
+            var apdu = CommandApdu({
+                cla: 0x00,
+                ins: 0xA4,
+                p1: 0x04,
+                p2: 0x00,
+                data: [0x31, 0x50, 0x41, 0x59]
+            });
+
+            var result = apdu.toString();
+
+            // CLA=00, INS=A4, P1=04, P2=00, LC=04, DATA=31504159, LE=00
+            assert.ok(result.toLowerCase().includes('00a40400'), 'Should contain command header');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Fixed bug where `toString()` method in `CommandApdu` referenced undefined `bytes` variable instead of `this.bytes`
- Added test coverage for `toString()` method
- Added `test` script to package.json

## Test Plan
- [x] Added unit tests for `toString()` method
- [x] Tests pass locally with `npm test`

Fixes #1