### PR TITLE
Replace deprecated Buffer() constructor with Buffer.from()

### DIFF
--- a/src/command-apdu.js
+++ b/src/command-apdu.js
@@ -70,7 +70,7 @@ CommandApdu.prototype.toByteArray = function() {
 };
 
 CommandApdu.prototype.toBuffer = function() {
-    return new Buffer(this.bytes);
+    return Buffer.from(this.bytes);
 };
 
 CommandApdu.prototype.setLe = function (le) {

--- a/test/command-apdu.test.js
+++ b/test/command-apdu.test.js
@@ -35,4 +35,35 @@ describe('CommandApdu', function() {
             assert.ok(result.toLowerCase().includes('00a40400'), 'Should contain command header');
         });
     });
+
+    describe('toBuffer()', function() {
+        it('should return a Buffer instance', function() {
+            var apdu = CommandApdu({
+                cla: 0x00,
+                ins: 0xA4,
+                p1: 0x04,
+                p2: 0x00
+            });
+
+            var result = apdu.toBuffer();
+
+            assert.ok(Buffer.isBuffer(result), 'toBuffer() should return a Buffer');
+        });
+
+        it('should contain correct bytes', function() {
+            var apdu = CommandApdu({
+                cla: 0x00,
+                ins: 0xA4,
+                p1: 0x04,
+                p2: 0x00
+            });
+
+            var result = apdu.toBuffer();
+
+            assert.strictEqual(result[0], 0x00, 'CLA should be 0x00');
+            assert.strictEqual(result[1], 0xA4, 'INS should be 0xA4');
+            assert.strictEqual(result[2], 0x04, 'P1 should be 0x04');
+            assert.strictEqual(result[3], 0x00, 'P2 should be 0x00');
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- Replaced deprecated `new Buffer()` constructor with `Buffer.from()` in `CommandApdu.toBuffer()`
- Added test coverage for `toBuffer()` method

## Why
The `Buffer()` constructor has been deprecated since Node.js v6.0.0 due to security concerns around uninitialized memory exposure.

## Test Plan
- [x] Added unit tests for `toBuffer()` method
- [x] Tests pass locally with `npm test`

Fixes #3