### PR TITLE
Rename buffer() to getBuffer() to fix property/method collision

### DIFF
--- a/src/response-apdu.js
+++ b/src/response-apdu.js
@@ -67,7 +67,7 @@ ResponseApdu.prototype.getStatusCode = function() {
 ResponseApdu.prototype.isOk = function() {
     return this.getStatusCode() === '9000';
 };
-ResponseApdu.prototype.buffer = function() {
+ResponseApdu.prototype.getBuffer = function() {
     return this.buffer;
 };
 ResponseApdu.prototype.hasMoreBytesAvailable = function() {

--- a/test/response-apdu.test.js
+++ b/test/response-apdu.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+var ResponseApdu = require('../lib/response-apdu');
+var assert = require('assert');
+
+describe('ResponseApdu', function() {
+    describe('getBuffer()', function() {
+        it('should return the original buffer', function() {
+            var originalBuffer = Buffer.from([0x90, 0x00]);
+            var response = ResponseApdu(originalBuffer);
+
+            var result = response.getBuffer();
+
+            assert.ok(Buffer.isBuffer(result), 'getBuffer() should return a Buffer');
+            assert.deepStrictEqual(result, originalBuffer, 'Should return the original buffer');
+        });
+    });
+
+    describe('getStatusCode()', function() {
+        it('should return last 4 hex characters as status code', function() {
+            var response = ResponseApdu(Buffer.from([0x6A, 0x82]));
+
+            assert.strictEqual(response.getStatusCode(), '6a82');
+        });
+
+        it('should extract status from longer response', function() {
+            var response = ResponseApdu(Buffer.from([0x01, 0x02, 0x03, 0x90, 0x00]));
+
+            assert.strictEqual(response.getStatusCode(), '9000');
+        });
+    });
+
+    describe('isOk()', function() {
+        it('should return true for 9000 status', function() {
+            var response = ResponseApdu(Buffer.from([0x90, 0x00]));
+
+            assert.strictEqual(response.isOk(), true);
+        });
+
+        it('should return false for error status', function() {
+            var response = ResponseApdu(Buffer.from([0x6A, 0x82]));
+
+            assert.strictEqual(response.isOk(), false);
+        });
+    });
+
+    describe('hasMoreBytesAvailable()', function() {
+        it('should return true for 61xx status', function() {
+            var response = ResponseApdu(Buffer.from([0x61, 0x10]));
+
+            assert.strictEqual(response.hasMoreBytesAvailable(), true);
+        });
+
+        it('should return false for 9000 status', function() {
+            var response = ResponseApdu(Buffer.from([0x90, 0x00]));
+
+            assert.strictEqual(response.hasMoreBytesAvailable(), false);
+        });
+    });
+
+    describe('numberOfBytesAvailable()', function() {
+        it('should return number of bytes from 61xx status', function() {
+            var response = ResponseApdu(Buffer.from([0x61, 0x10]));
+
+            assert.strictEqual(response.numberOfBytesAvailable(), 16);
+        });
+    });
+
+    describe('isWrongLength()', function() {
+        it('should return true for 6cxx status', function() {
+            var response = ResponseApdu(Buffer.from([0x6C, 0x20]));
+
+            assert.strictEqual(response.isWrongLength(), true);
+        });
+
+        it('should return false for 9000 status', function() {
+            var response = ResponseApdu(Buffer.from([0x90, 0x00]));
+
+            assert.strictEqual(response.isWrongLength(), false);
+        });
+    });
+
+    describe('correctLength()', function() {
+        it('should return correct length from 6cxx status', function() {
+            var response = ResponseApdu(Buffer.from([0x6C, 0x20]));
+
+            assert.strictEqual(response.correctLength(), 32);
+        });
+    });
+
+    describe('toString()', function() {
+        it('should return hex string of response', function() {
+            var response = ResponseApdu(Buffer.from([0x90, 0x00]));
+
+            assert.strictEqual(response.toString(), '9000');
+        });
+    });
+
+    describe('getStatus()', function() {
+        it('should return status object with code and meaning', function() {
+            var response = ResponseApdu(Buffer.from([0x90, 0x00]));
+
+            var status = response.getStatus();
+
+            assert.strictEqual(status.code, '9000');
+            assert.strictEqual(status.meaning, 'Normal processing');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Renamed `buffer()` method to `getBuffer()` in `ResponseApdu` to avoid shadowing by the `buffer` property
- Added comprehensive test coverage for `ResponseApdu` class

## Breaking Change
This is a breaking change for anyone using `response.buffer()`. They should update to `response.getBuffer()`.

## Why
The `ResponseApdu` constructor assigns `this.buffer = buffer`, which shadows the prototype method `ResponseApdu.prototype.buffer()`, making it inaccessible.

## Test Plan
- [x] Added unit tests for all `ResponseApdu` methods
- [x] Tests pass locally with `npm test`

Fixes #5