### PR TITLE
Remove unused apdu dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "homepage": "https://github.com/tomkp/iso7816",
   "dependencies": {
-    "apdu": "^0.0.3",
     "card-reader": "^1.0.3",
     "hexify": "^1.0.1"
   },


### PR DESCRIPTION
## Summary
Removed the `apdu` package from dependencies as it was never imported or used in the codebase.

## Verification
- Searched all source files for `apdu` imports: none found
- All tests pass after removal

## Test Plan
- [x] Tests pass locally with `npm test`

Fixes #7