### PR TITLE
Replace deprecated card-reader with smartcard package

### DIFF
--- a/demo/iso7816-demo.js
+++ b/demo/iso7816-demo.js
@@ -1,39 +1,28 @@
-var devices = require('card-reader');
-var iso7816 = require('../lib/iso7816-application');
+const { Devices } = require('smartcard');
+const iso7816 = require('../lib/iso7816-application');
 
+const devices = new Devices();
 
-devices.on('device-activated', function (event) {
-    console.log(`Device '${event.reader.name}' activated, devices: ${devices.listDevices()}`);
+devices.on('reader-attached', function (reader) {
+    console.log(`Reader '${reader.name}' attached`);
 });
 
-devices.on('device-deactivated', function (event) {
-    console.log(`Device '${event.reader.name}' deactivated, devices: ${devices.listDevices()}`);
+devices.on('reader-detached', function (reader) {
+    console.log(`Reader '${reader.name}' detached`);
 });
 
-devices.on('card-removed', function (event) {
-    console.log(`Card removed from '${event.reader.name}' `);
+devices.on('card-removed', function ({ reader }) {
+    console.log(`Card removed from '${reader.name}'`);
 });
 
-devices.on('command-issued', function (event) {
-    console.log(`Command '${event.command}' issued to '${event.reader.name}' `);
+devices.on('error', function (error) {
+    console.log(`Error: ${error.message}`);
 });
 
-devices.on('response-received', function (event) {
-    console.log(`Response '${event.response}' received from '${event.reader.name}' in response to '${event.command}'`);
-});
+devices.on('card-inserted', function ({ reader, card }) {
+    console.log(`Card inserted into '${reader.name}', atr: '${card.atr.toString('hex')}'`);
 
-devices.on('error', function (event) {
-    console.log(`Error '${event.error}' received`);
-});
-
-devices.on('card-inserted', function (event) {
-
-    console.log(`List devices: ${devices.listDevices()}`);
-
-    var reader = event.reader;
-    console.log(`Card inserted into '${reader.name}', atr: '${event.status.atr.toString('hex')}'`);
-
-    var application = iso7816(devices, reader);
+    const application = iso7816(card);
     application
         .selectFile([0x31, 0x50, 0x41, 0x59, 0x2E, 0x53, 0x59, 0x53, 0x2E, 0x44, 0x44, 0x46, 0x30, 0x31])
         .then(function (response) {
@@ -41,5 +30,6 @@ devices.on('card-inserted', function (event) {
         }).catch(function (error) {
             console.error('Error:', error, error.stack);
         });
-
 });
+
+devices.start();

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "homepage": "https://github.com/tomkp/iso7816",
   "dependencies": {
-    "card-reader": "^1.0.3",
-    "hexify": "^1.0.1"
+    "hexify": "^1.0.1",
+    "smartcard": "^3.2.1"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
## Summary
Migrates from the deprecated `card-reader` package to the maintained `smartcard` package.

## Breaking Changes
The API signature has changed:

**Before:**
```javascript
const iso7816 = require('iso7816');
const application = iso7816(devices, reader);
```

**After:**
```javascript
const iso7816 = require('iso7816');
const application = iso7816(card);
```

## Changes
- Updated dependency from `card-reader` to `smartcard` ^3.2.1
- Simplified `Iso7816` constructor to accept card object directly
- Updated demo to use new smartcard `Devices` API
- Updated README with new API documentation and examples

## Migration Guide
1. Update your event handlers to use the new smartcard event structure
2. Pass the `card` object directly to `iso7816()` instead of `(devices, reader)`

```javascript
// Old code
devices.on('card-inserted', function (reader, status) {
    const application = iso7816(devices, reader);
});

// New code  
devices.on('card-inserted', function ({ reader, card }) {
    const application = iso7816(card);
});
```

## Test Plan
- [x] Tests pass locally with `npm test`
- [x] Demo code updated and compiles

Fixes #9