### PR TITLE
Add TypeScript type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "smartcard": "^3.2.1"
       },
       "devDependencies": {
-        "mocha": "^11.7.5"
+        "@types/node": "^25.0.3",
+        "mocha": "^11.7.5",
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -131,6 +133,16 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/argparse": {
@@ -1003,6 +1015,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
   "description": "ISO 7816 smartcard communication library",
   "type": "module",
   "main": "src/iso7816-application.js",
+  "types": "src/index.d.ts",
   "exports": {
-    ".": "./src/iso7816-application.js"
+    ".": {
+      "types": "./src/index.d.ts",
+      "default": "./src/iso7816-application.js"
+    }
   },
   "files": [
     "src"
@@ -26,7 +30,8 @@
     "iso-7816",
     "chip-and-pin",
     "emv",
-    "esm"
+    "esm",
+    "typescript"
   ],
   "license": "MIT",
   "bugs": {
@@ -42,6 +47,8 @@
     "smartcard": "^3.2.1"
   },
   "devDependencies": {
-    "mocha": "^11.7.5"
+    "@types/node": "^25.0.3",
+    "mocha": "^11.7.5",
+    "typescript": "^5.9.3"
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,153 @@
+/**
+ * ISO 7816 Smartcard Communication Library
+ */
+
+/**
+ * Options for creating a CommandApdu
+ */
+export interface CommandApduOptions {
+    /** Class byte */
+    cla: number;
+    /** Instruction byte */
+    ins: number;
+    /** Parameter 1 */
+    p1: number;
+    /** Parameter 2 */
+    p2: number;
+    /** Command data */
+    data?: number[];
+    /** Expected response length */
+    le?: number;
+    /** Total size (optional, auto-calculated) */
+    size?: number;
+}
+
+/**
+ * APDU Command object
+ */
+export interface CommandApdu {
+    /** Internal byte array */
+    bytes: number[];
+    /** Convert to hex string */
+    toString(): string;
+    /** Get bytes as array */
+    toByteArray(): number[];
+    /** Convert to Node.js Buffer */
+    toBuffer(): Buffer;
+    /** Update expected response length */
+    setLe(le: number): void;
+}
+
+/**
+ * Create a new CommandApdu
+ */
+export function CommandApdu(options: CommandApduOptions): CommandApdu;
+
+/**
+ * Status information from a response
+ */
+export interface Status {
+    /** 4-character hex status code (e.g., "9000") */
+    code: string;
+    /** Human-readable meaning of the status */
+    meaning: string;
+}
+
+/**
+ * APDU Response object
+ */
+export interface ResponseApdu {
+    /** Raw response buffer */
+    buffer: Buffer;
+    /** Response as hex string */
+    data: string;
+    /** Get status code and meaning */
+    getStatus(): Status;
+    /** Get 4-character hex status code */
+    getStatusCode(): string;
+    /** Check if status is 9000 (success) */
+    isOk(): boolean;
+    /** Get the raw buffer */
+    getBuffer(): Buffer;
+    /** Check if more bytes are available (61xx status) */
+    hasMoreBytesAvailable(): boolean;
+    /** Get number of additional bytes available */
+    numberOfBytesAvailable(): number;
+    /** Check if wrong length was specified (6cxx status) */
+    isWrongLength(): boolean;
+    /** Get the correct length from 6cxx response */
+    correctLength(): number;
+    /** Convert to hex string */
+    toString(): string;
+}
+
+/**
+ * Create a new ResponseApdu from a buffer
+ */
+export function ResponseApdu(buffer: Buffer): ResponseApdu;
+
+/**
+ * Card interface (from smartcard package)
+ */
+export interface Card {
+    /** Card ATR (Answer To Reset) */
+    atr: Buffer;
+    /** Transmit APDU command to card */
+    transmit(data: Buffer | number[]): Promise<Buffer>;
+}
+
+/**
+ * ISO 7816 Application interface
+ */
+export interface Iso7816 {
+    /** The underlying card */
+    card: Card;
+
+    /**
+     * Issue a raw APDU command
+     * @param commandApdu The command to send
+     * @returns Promise resolving to the response
+     */
+    issueCommand(commandApdu: CommandApdu): Promise<ResponseApdu>;
+
+    /**
+     * Select a file on the smartcard
+     * @param bytes File identifier bytes (e.g., AID)
+     * @param p1 P1 parameter (default: 0x04)
+     * @param p2 P2 parameter (default: 0x00)
+     * @returns Promise resolving to the response
+     */
+    selectFile(bytes: number[], p1?: number, p2?: number): Promise<ResponseApdu>;
+
+    /**
+     * Get additional response bytes
+     * @param length Number of bytes to retrieve
+     * @returns Promise resolving to the response
+     */
+    getResponse(length: number): Promise<ResponseApdu>;
+
+    /**
+     * Read a record from a file
+     * @param sfi Short File Identifier
+     * @param record Record number
+     * @returns Promise resolving to the response
+     */
+    readRecord(sfi: number, record: number): Promise<ResponseApdu>;
+
+    /**
+     * Get data from the card
+     * @param p1 P1 parameter
+     * @param p2 P2 parameter
+     * @returns Promise resolving to the response
+     */
+    getData(p1: number, p2: number): Promise<ResponseApdu>;
+}
+
+/**
+ * Create an ISO 7816 application for the given card
+ * @param card A card object from the smartcard package
+ * @returns An Iso7816 application instance
+ */
+declare function createIso7816(card: Card): Iso7816;
+
+export default createIso7816;


### PR DESCRIPTION
## Summary
Added comprehensive TypeScript type definitions for improved developer experience.

## Changes
- Added `src/index.d.ts` with full type definitions
- Added `types` field to package.json
- Added TypeScript and @types/node as dev dependencies
- Updated exports to include types

## Type Coverage
- `CommandApdu` factory and instance interface
- `ResponseApdu` factory and instance interface
- `Iso7816` application factory and instance interface
- `Card` interface (from smartcard package)
- All method signatures with JSDoc comments

## Test Plan
- [x] Type definitions validate with `tsc --noEmit`
- [x] All existing tests pass

Fixes #13