### PR TITLE
Move smartcard to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iso7816",
   "version": "1.0.20",
-  "description": "ISO 7816 smartcard communication library",
+  "description": "ISO 7816 APDU command and response handling library",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -50,15 +50,13 @@
     "url": "https://github.com/tomkp/iso7816.git"
   },
   "homepage": "https://github.com/tomkp/iso7816",
-  "dependencies": {
-    "smartcard": "^3.2.1"
-  },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@types/node": "^22.0.0",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.7.4",
+    "smartcard": "^3.2.1",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.50.1"
   }

--- a/src/iso7816-application.ts
+++ b/src/iso7816-application.ts
@@ -26,7 +26,7 @@ export const Instructions = {
 } as const;
 
 /**
- * Card interface (from smartcard package)
+ * Card interface for any transport that can send/receive APDUs
  */
 export interface Card {
     /** Card ATR (Answer To Reset) */
@@ -36,7 +36,7 @@ export interface Card {
 }
 
 /**
- * ISO 7816 Application class for smartcard communication
+ * ISO 7816 Application class for APDU communication
  */
 export class Iso7816 {
     private readonly _card: Card;


### PR DESCRIPTION
## Summary
The core library doesn't require `smartcard` - it works with any transport that can send/receive byte arrays. Move it to devDependencies since it's only used for the demo.

## Changes
- Move `smartcard` from dependencies to devDependencies
- Update package description: "ISO 7816 APDU command and response handling library"
- Rewrite README to clarify transport-agnostic design
- Add "With custom transport" example
- Add "Building APDUs directly" example
- Remove hardware-specific sections (card reader photos)
- Update Card interface JSDoc comment

## Test plan
- [x] All 35 tests pass
- [x] ESLint passes
- [x] Prettier formatting applied

Fixes #32