### PR TITLE
Colocate tests with source files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,8 @@ export default tseslint.config(
         ignores: ['dist/', 'node_modules/'],
     },
     {
-        files: ['**/*.ts'],
+        files: ['src/**/*.ts'],
+        ignores: ['**/*.test.ts'],
         languageOptions: {
             parserOptions: {
                 projectService: true,

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
-    "format": "prettier --write src/ test/",
-    "format:check": "prettier --check src/ test/",
+    "format": "prettier --write src/",
+    "format:check": "prettier --check src/",
     "prepublishOnly": "npm run build",
     "release:patch": "npm run build && npm version patch && git push && npm publish"
   },

--- a/src/command-apdu.test.ts
+++ b/src/command-apdu.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createCommandApdu } from '../src/index.js';
+import { createCommandApdu } from './index.js';
 
 describe('CommandApdu', () => {
     describe('toString()', () => {

--- a/src/iso7816-application.test.ts
+++ b/src/iso7816-application.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import createIso7816 from '../src/iso7816-application.js';
-import type { Card } from '../src/iso7816-application.js';
+import createIso7816 from './iso7816-application.js';
+import type { Card } from './iso7816-application.js';
 
 describe('Iso7816', () => {
     describe('issueCommand()', () => {

--- a/src/response-apdu.test.ts
+++ b/src/response-apdu.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createResponseApdu } from '../src/index.js';
+import { createResponseApdu } from './index.js';
 
 describe('ResponseApdu', () => {
     describe('constructor', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "test"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
             provider: 'v8',
             reporter: ['text', 'html', 'lcov'],
             include: ['src/**/*.ts'],
-            exclude: ['src/**/*.d.ts'],
+            exclude: ['src/**/*.d.ts', 'src/**/*.test.ts'],
         },
     },
 });


### PR DESCRIPTION
## Summary
- Moves test files from `test/` to `src/` alongside their corresponding source files
- Updates imports to use relative paths
- Configures tsconfig, vitest, and ESLint to handle colocated tests

## Changes
- `command-apdu.test.ts` → `src/command-apdu.test.ts`
- `response-apdu.test.ts` → `src/response-apdu.test.ts`
- `iso7816-application.test.ts` → `src/iso7816-application.test.ts`

## Test plan
- [x] All 35 tests pass
- [x] Test files excluded from dist (verified with `npm pack --dry-run`)
- [x] ESLint passes
- [x] Prettier passes

Fixes #36