### PR TITLE
Update Node.js engine requirement to >=20.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
 
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "release:patch": "npm run lint && npm run typecheck && npm test && npm run build && npm version patch && git push --follow-tags && npm publish"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "author": "tomkp <tom@tomkp.com>",
   "keywords": [


### PR DESCRIPTION
## Summary
Node 18 reached end-of-life in April 2025. Updates engine requirement and CI matrix to target current LTS versions.

## Changes
- Updates `engines.node` from `>=18.0.0` to `>=20.0.0`
- Updates CI matrix from `[18, 20, 22]` to `[20, 22, 24]`

## Test plan
- [x] All 38 tests pass
- [x] CI will test on Node 20, 22, and 24

Fixes #44